### PR TITLE
Plugins: Parquet output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tmp*
 temp*
 test-output
 build.log
+cache
 
 # other scm
 .svn

--- a/driver/src/main/scala/com/stratio/sparkta/driver/service/StreamingContextService.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/service/StreamingContextService.scala
@@ -31,7 +31,7 @@ import org.apache.spark.streaming.{Duration, StreamingContext}
 import org.reflections.Reflections
 
 import com.stratio.sparkta.aggregator.{DataCube, Rollup}
-import com.stratio.sparkta.driver.dto.{PolicyElementDto, AggregationPoliciesDto}
+import com.stratio.sparkta.driver.dto.{AggregationPoliciesDto, PolicyElementDto}
 import com.stratio.sparkta.driver.exception.DriverException
 import com.stratio.sparkta.driver.factory._
 import com.stratio.sparkta.sdk.TypeOp.TypeOp
@@ -84,9 +84,9 @@ object SparktaJob {
   val OperatorNamePropertyKey = "name"
 
   @tailrec
-  def applyParsers(input: DStream[Event], parsers: Seq[Parser]): DStream[Event] = {
-    if (parsers.size > 0) applyParsers(input.map(event => parsers.head.parse(event)), parsers.drop(1))
-    else input
+  def applyParsers(input: DStream[Event], parsers: Seq[Parser]): DStream[Event] = parsers.headOption match {
+    case Some(parser: Parser) => applyParsers(input.map(event => parser.parse(event)), parsers.drop(1))
+    case None => input
   }
 
   val getClasspathMap: Map[String, String] = {
@@ -123,7 +123,7 @@ object SparktaJob {
     tryToInstantiate[Parser](p.elementType, (c) =>
       instantiateParameterizable[Parser](c, p.configuration)))
 
-  private def createOperator(op2: PolicyElementDto) : Operator= {
+  private def createOperator(op2: PolicyElementDto): Operator = {
     tryToInstantiate[Operator](op2.elementType,
       (c) => instantiateParameterizable[Operator](c,
         op2.configuration + (OperatorNamePropertyKey -> new JsoneyString(op2.name))))
@@ -131,13 +131,13 @@ object SparktaJob {
 
   def operators(apConfig: AggregationPoliciesDto): Seq[Operator] =
     apConfig.operators
-      .map(op2 => createOperator (op2))
+      .map(op2 => createOperator(op2))
 
   def outputs(apConfig: AggregationPoliciesDto,
               sparkContext: SparkContext,
               bcOperatorsKeyOperation: Option[Broadcast[Map[String, (WriteOp, TypeOp)]]],
               bcRollupOperatorSchema: Option[Broadcast[Seq[TableSchema]]],
-              timeName : String): Seq[(String, Output)] =
+              timeName: String): Seq[(String, Output)] =
     apConfig.outputs.map(o =>
       (o.name, tryToInstantiate[Output](o.elementType, (c) =>
         c.getDeclaredConstructor(
@@ -226,7 +226,8 @@ object SparktaJob {
 
   def saveRawData(apConfig: AggregationPoliciesDto, sqlContext: SQLContext, input: DStream[Event]): Unit = {
     if (apConfig.saveRawData.toBoolean) {
-      def rawDataStorage: RawDataStorageService = new RawDataStorageService(sqlContext, apConfig.rawDataParquetPath,apConfig.rawDataGranularity)
+      def rawDataStorage: RawDataStorageService =
+        new RawDataStorageService(sqlContext, apConfig.rawDataParquetPath, apConfig.rawDataGranularity)
       rawDataStorage.save(input)
     }
   }

--- a/plugins/bucketer-dateTime/pom.xml
+++ b/plugins/bucketer-dateTime/pom.xml
@@ -30,8 +30,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
+            <groupId>com.github.nscala-time</groupId>
+            <artifactId>nscala-time_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/output-parquet/pom.xml
+++ b/plugins/output-parquet/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2015 Stratio (http://stratio.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugins</artifactId>
+        <groupId>com.stratio.sparkta</groupId>
+        <version>0.5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>output-parquet</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.nscala-time</groupId>
+            <artifactId>nscala-time_${scala.binary.version}</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/plugins/output-parquet/src/main/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutput.scala
+++ b/plugins/output-parquet/src/main/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutput.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.plugin.output.parquet
+
+import java.io.{Serializable => JSerializable}
+import scala.util.Try
+
+import com.github.nscala_time.time.StaticDateTime
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql._
+import org.apache.spark.{Logging, SparkContext}
+
+import com.stratio.sparkta.sdk.TypeOp._
+import com.stratio.sparkta.sdk.ValidatingPropertyMap._
+import com.stratio.sparkta.sdk.WriteOp.WriteOp
+import com.stratio.sparkta.sdk._
+
+/**
+ * This output save as parquet file the information.
+ * @param keyName
+ * @param properties
+ * @param sparkContext
+ * @param operationTypes
+ * @param bcSchema
+ */
+class ParquetOutput(keyName: String,
+                    properties: Map[String, JSerializable],
+                    @transient sparkContext: SparkContext,
+                    operationTypes: Option[Broadcast[Map[String, (WriteOp, TypeOp)]]],
+                    bcSchema: Option[Broadcast[Seq[TableSchema]]],
+                    timeName: String)
+  extends Output(keyName, properties, sparkContext, operationTypes, bcSchema, timeName: String) with Logging {
+
+  override val supportedWriteOps = Seq(WriteOp.Inc, WriteOp.IncBig, WriteOp.Set, WriteOp.Max, WriteOp.Min,
+    WriteOp.AccAvg, WriteOp.AccMedian, WriteOp.AccVariance, WriteOp.AccStddev, WriteOp.FullText, WriteOp.AccSet)
+
+  override val multiplexer = Try(properties.getString("multiplexer").toBoolean).getOrElse(false)
+
+  override val isAutoCalculateId = Try(properties.getString("isAutoCalculateId").toBoolean).getOrElse(false)
+
+  final val Slash: String = "/"
+
+  def timeSuffix: String = Slash + DateOperations.dateFromGranularity(StaticDateTime.now, timeName)
+
+  val path = properties.getString("path", None)
+
+  override def upsert(dataFrame: DataFrame, tableName: String): Unit = {
+    require(path.isDefined, bcSchema.isDefined)
+    dataFrame.save(s"${path.get}$timeSuffix", "parquet", SaveMode.Append)
+  }
+}

--- a/plugins/parser-datetime/pom.xml
+++ b/plugins/parser-datetime/pom.xml
@@ -30,8 +30,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
+            <groupId>com.github.nscala-time</groupId>
+            <artifactId>nscala-time_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -57,6 +57,7 @@
         <module>bucketer-tag</module>
         <module>bucketer-hierarchy</module>
         <module>input-rabbitMQ</module>
+        <module>output-parquet</module>
     </modules>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <scala.version>2.10.4</scala.version>
         <spark.version>1.3.0</spark.version>
         <slf4j.version>1.7.7</slf4j.version>
-        <joda.time.version>2.5</joda.time.version>
+        <nscala.time.version>2.0.0</nscala.time.version>
         <scalatest.version>2.2.2</scalatest.version>
         <mockito.version>1.10.5</mockito.version>
     </properties>
@@ -166,9 +166,9 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${joda.time.version}</version>
+                <groupId>com.github.nscala-time</groupId>
+                <artifactId>nscala-time_${scala.binary.version}</artifactId>
+                <version>${nscala.time.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,8 +42,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
+            <groupId>com.github.nscala-time</groupId>
+            <artifactId>nscala-time_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.datastax.spark</groupId>


### PR DESCRIPTION
#### Description
Output to parquet files. The partitions will come in next iterations. Changed JodaTime dependency by Nscala-time (Scala wrapper for JodaTime). See https://github.com/nscala-time/nscala-time.

#### Reviewer
@gserranojc   

#### Test
All passed.

#### Scalastyle
All test passed.